### PR TITLE
fix: Gpu from vulkan by check deviceType

### DIFF
--- a/src/modules/gpumodule.rs
+++ b/src/modules/gpumodule.rs
@@ -270,8 +270,16 @@ fn gpu_from_vulkaninfo(allow_igpu: bool) -> Option<String> {
             continue;
         }
 
+        let type_needle = b"deviceType";
+        let is_integrated = if let Some(type_pos) = memmem::find(&stdout[search_pos..], type_needle) {
+            let type_line = &stdout[search_pos + type_pos .. search_pos + type_pos + 100];
+            type_line.windows(14).any(|w| w == b"INTEGRATED_GPU")
+        } else {
+            false
+        };
+
         // Skip integrated GPU unless allowed
-        if !allow_igpu && name.contains("Processor") {
+        if !allow_igpu && is_integrated || name.contains("Processor") {
             search_pos = pos + needle.len();
             continue;
         }


### PR DESCRIPTION
fix integrated gpu filter in gpu from vulkan by checking deviceType

<details>
<summary>vulkan info</summary>

```
==========
VULKANINFO
==========

Vulkan Instance Version: 1.4.341


Instance Extensions: count = 27
-------------------------------
VK_EXT_acquire_drm_display             : extension revision 1
VK_EXT_acquire_xlib_display            : extension revision 1
VK_EXT_debug_report                    : extension revision 10
VK_EXT_debug_utils                     : extension revision 2
VK_EXT_direct_mode_display             : extension revision 1
VK_EXT_display_surface_counter         : extension revision 1
VK_EXT_headless_surface                : extension revision 1
VK_EXT_layer_settings                  : extension revision 2
VK_EXT_surface_maintenance1            : extension revision 1
VK_EXT_swapchain_colorspace            : extension revision 5
VK_KHR_device_group_creation           : extension revision 1
VK_KHR_display                         : extension revision 23
VK_KHR_external_fence_capabilities     : extension revision 1
VK_KHR_external_memory_capabilities    : extension revision 1
VK_KHR_external_semaphore_capabilities : extension revision 1
VK_KHR_get_display_properties2         : extension revision 1
VK_KHR_get_physical_device_properties2 : extension revision 2
VK_KHR_get_surface_capabilities2       : extension revision 1
VK_KHR_portability_enumeration         : extension revision 1
VK_KHR_surface                         : extension revision 25
VK_KHR_surface_maintenance1            : extension revision 1
VK_KHR_surface_protected_capabilities  : extension revision 1
VK_KHR_wayland_surface                 : extension revision 6
VK_KHR_xcb_surface                     : extension revision 6
VK_KHR_xlib_surface                    : extension revision 6
VK_LUNARG_direct_driver_loading        : extension revision 1
VK_NV_display_stereo                   : extension revision 1

Instance Layers: count = 9
--------------------------
VK_LAYER_MANGOHUD_overlay_x86_64  Vulkan Hud Overlay                                           1.3.0    version 1
VK_LAYER_MESA_anti_lag            Open-source implementation of the VK_AMD_anti_lag extension. 1.4.303  version 1
VK_LAYER_MESA_device_select       Linux device selection layer                                 1.4.303  version 1
VK_LAYER_NV_optimus               NVIDIA Optimus layer                                         1.4.325  version 1
VK_LAYER_NV_present               NVIDIA Presentation Layer                                    1.4.325  version 1
VK_LAYER_VALVE_steam_fossilize_32 Steam Pipeline Caching Layer                                 1.3.207  version 1
VK_LAYER_VALVE_steam_fossilize_64 Steam Pipeline Caching Layer                                 1.3.207  version 1
VK_LAYER_VALVE_steam_overlay_32   Steam Overlay Layer                                          1.3.207  version 1
VK_LAYER_VALVE_steam_overlay_64   Steam Overlay Layer                                          1.3.207  version 1

Devices:
========
GPU0:
	apiVersion         = 1.4.335
	driverVersion      = 26.0.1
	vendorID           = 0x8086
	deviceID           = 0xa7a0
	deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
	deviceName         = Intel(R) Iris(R) Xe Graphics (RPL-P)
	driverID           = DRIVER_ID_INTEL_OPEN_SOURCE_MESA
	driverName         = Intel open-source Mesa driver
	driverInfo         = Mesa 26.0.1-arch1.1
	conformanceVersion = 1.4.0.0
	deviceUUID         = 8680a0a7-0400-0000-0002-000000000000
	driverUUID         = 30197fcb-8a7e-d879-bf7f-c30f00ec8457
GPU1:
	apiVersion         = 1.4.325
	driverVersion      = 590.48.1.0
	vendorID           = 0x10de
	deviceID           = 0x28a1
	deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
	deviceName         = NVIDIA GeForce RTX 4050 Laptop GPU
	driverID           = DRIVER_ID_NVIDIA_PROPRIETARY
	driverName         = NVIDIA
	driverInfo         = 590.48.01
	conformanceVersion = 1.4.3.0
	deviceUUID         = 80b6a1a2-9ddc-1404-89a8-a6ad6c5b568a
	driverUUID         = cacc304f-7167-5cf5-a6bd-293f0657ef84
```

</details>

## Before

<img width="880" height="499" alt="image" src="https://github.com/user-attachments/assets/7c43f07a-2259-4b85-897e-60230502544c" />


## After

<img width="883" height="496" alt="image" src="https://github.com/user-attachments/assets/b1f1adb6-1d6b-48fc-816c-dd2a4e1dc144" />
